### PR TITLE
Fixed environment variable definition separators for sidekiqz2

### DIFF
--- a/include/configs/zynq_zc70x_sidekiqz2.h
+++ b/include/configs/zynq_zc70x_sidekiqz2.h
@@ -92,7 +92,7 @@
 		"fi; " \
 		"envversion;setenv bootargs uio_pdrv_genirq.of_id=generic-uio console=ttyPS0,115200 maxcpus=${maxcpus} " \
 		"rootfstype=ramfs root=/dev/ram0 rw earlyprintk uboot=\"${uboot-version}\" " \
-		"&& bootm ${fit_load_address}#${fit_config} || echo BOOT failed entering DFU mode ... && run dfu_sf \n" \
+		"&& bootm ${fit_load_address}#${fit_config} || echo BOOT failed entering DFU mode ... && run dfu_sf \0" \
 	"qspiboot=adi_hwref; set stdout serial@e0001000; " \
 			"if gpio input 48; then " \
 				"echo DFU pin asserted  && run dfu_sf; " \
@@ -109,7 +109,7 @@
 			"rootfstype=ramfs root=/dev/ram0 rw quiet loglevel=4 uboot=\"${uboot-version}\" && " \
 			"bootm ${fit_load_address}#${fit_config} || set stdout serial@e0001000;echo BOOT failed entering DFU mode ... && run dfu_sf \0" \
 	"jtagboot=env default -a;sf probe && sf protect unlock 0 100000 && run dfu_sf;\0" \
-	"thor_ram=run dfu_ram_info && thordown 0 ram 0\n" \
+	"thor_ram=run dfu_ram_info && thordown 0 ram 0\0" \
 	"uenvboot=" \
 		"if run loadbootenv; then " \
 			"echo Loaded environment from ${bootenv}; " \


### PR DESCRIPTION
The default uboot environment for the sidekiqz2 target has a pair of line-ending errors, where \0 was replaced by \n. This PR corrects those errors.

The impact of this issue is that qspiboot and uenvboot become undefined in the default uboot environment. This is a problem, because if the primary flash-based uboot-env is missing/corrupt, falling back to the default environment will not correctly place the device into DFU mode if the kernel is also missing/corrupt (since that functionality is in qspiboot).