### PR TITLE
configs: zynq-common: Fix 1r1t mode

### DIFF
--- a/include/configs/zynq-common.h
+++ b/include/configs/zynq-common.h
@@ -309,6 +309,7 @@
 		"fi; " \
 		"if test ${mode} = 1r1t || test ! \"${model}\" = \"Analog Devices PlutoSDR Rev.C (Z7010/AD9363)\"; then " \
 			"fdt rm /amba/spi@e0006000/ad9361-phy@0 adi,2rx-2tx-mode-enable; " \
+			"fdt set /fpga-axi/cf-ad9361-dds-core-lpc@79024000 compatible adi,axi-ad9364-dds-6.00.a; " \
 		"fi; " \
 		"if test -n ${cs_gpio}; then " \
 			"fdt set /amba/axi_quad_spi@7C430000/ cs-gpios \"<0x06 ${cs_gpio} 0>\"; " \


### PR DESCRIPTION
When selecting 1r1t mode set DDS to point to the ad9464 configuration.

Fixes: 469a0fd988fb ("configs: zynq-common: Add environment configuration for RevC")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>