### PR TITLE
ci,azure-pipelines: add initial CI integration for Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,38 @@
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+jobs:
+- job: 'SupportedBoards'
+  strategy:
+    matrix:
+      zynq_zed_defconfig:
+        CI_DEFCONFIG: 'zynq_zed_defconfig'
+        ARCH: arm
+      zynq_coraz7_defconfig:
+        CI_DEFCONFIG: 'zynq_coraz7_defconfig'
+        ARCH: arm
+      zynq_adrv9361_defconfig:
+        CI_DEFCONFIG: 'zynq_adrv9361_defconfig'
+        ARCH: arm
+      zynq_adrv9364_defconfig:
+        CI_DEFCONFIG: 'zynq_adrv9364_defconfig'
+        ARCH: arm
+      zynq_zc702_defconfig:
+        CI_DEFCONFIG: 'zynq_zc702_defconfig'
+        ARCH: arm
+      zynq_zc706_defconfig:
+        CI_DEFCONFIG: 'zynq_zc706_defconfig'
+        ARCH: arm
+      xilinx_zynqmp_zcu102_rev1_0_defconfig:
+        CI_DEFCONFIG: 'xilinx_zynqmp_zcu102_rev1_0_defconfig'
+        ARCH: arm64
+      adi_zynqmp_adrv9009_zu11eg_adrv2crr_fmc_defconfig:
+        CI_DEFCONFIG: 'adi_zynqmp_adrv9009_zu11eg_adrv2crr_fmc_defconfig'
+        ARCH: arm64
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./ci/run_build.sh
+    displayName: "Build for $(CI_DEFCONFIG)"

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -e
+
+if [ -z "$NUM_JOBS" ] ; then
+	NUM_JOBS=$(getconf _NPROCESSORS_ONLN)
+	NUM_JOBS=${NUM_JOBS:-1}
+fi
+
+COMMON_DEPS="make bc u-boot-tools flex bison libssl-dev"
+
+install_deps() {
+	sudo apt-get -qq update
+
+	if [ "$ARCH" = "arm64" ] ; then
+		GCC_PKG="gcc-aarch64-linux-gnu"
+		export CROSS_COMPILE=aarch64-linux-gnu-
+	fi
+
+	if [ "$ARCH" = "arm" ] ; then
+		GCC_PKG="gcc-arm-linux-gnueabihf"
+		export CROSS_COMPILE=arm-linux-gnueabihf-
+	fi
+
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		$GCC_PKG $COMMON_DEPS
+
+}
+
+build_default() {
+	install_deps
+
+	make $CI_DEFCONFIG
+	make V=s -j${NUM_JOBS}
+}
+
+BUILD_TYPE="${BUILD_TYPE:-default}"
+
+build_${BUILD_TYPE}


### PR DESCRIPTION
The change adds a minimal CI integration for Azure Pipelines.
This repo rarely gets updated, so there aren't any special triggering
rules. All branches and PRs will trigger a build.

Building supported boards & carriers.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>