### PR TITLE
[pluto] ci,pluto,m2k,azure-pipelines: add initial CI integration for Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,20 @@
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+jobs:
+- job: 'ADALM'
+  strategy:
+    matrix:
+      zynq_m2k_defconfig:
+        CI_DEFCONFIG: 'zynq_m2k_defconfig'
+        ARCH: arm
+      zynq_pluto_defconfig:
+        CI_DEFCONFIG: 'zynq_pluto_defconfig'
+        ARCH: arm
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./ci/run_build.sh
+    displayName: "Build for $(CI_DEFCONFIG)"

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+
+if [ -z "$NUM_JOBS" ] ; then
+	NUM_JOBS=$(getconf _NPROCESSORS_ONLN)
+	NUM_JOBS=${NUM_JOBS:-1}
+fi
+
+COMMON_DEPS="make bc u-boot-tools flex bison libssl-dev"
+
+install_deps() {
+	sudo apt-get -qq update
+
+	if [ "$ARCH" = "arm64" ] ; then
+		GCC_PKG="gcc-aarch64-linux-gnu"
+		export CROSS_COMPILE=aarch64-linux-gnu-
+		export ARCH=arm
+	fi
+
+	if [ "$ARCH" = "arm" ] ; then
+		GCC_PKG="gcc-arm-linux-gnueabihf"
+		export CROSS_COMPILE=arm-linux-gnueabihf-
+	fi
+
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		$GCC_PKG $COMMON_DEPS
+
+}
+
+build_default() {
+	install_deps
+
+	make $CI_DEFCONFIG
+	make V=s -j${NUM_JOBS}
+}
+
+BUILD_TYPE="${BUILD_TYPE:-default}"
+
+build_${BUILD_TYPE}


### PR DESCRIPTION
The change adds a minimal CI integration for Azure Pipelines for the ADALM
Pluto and ADALM 2000 boards.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>