### PR TITLE
Add GitHub Actions workflow for building U-Boot

### DIFF
--- a/.github/workflows/build_uboot.yml
+++ b/.github/workflows/build_uboot.yml
@@ -1,0 +1,191 @@
+name: Build U-Boot for Xilinx Platforms
+# This workflow builds U-Boot for various Xilinx platforms.
+
+on:
+  workflow_dispatch:
+    inputs:
+      vivado_version:
+        description: 'Vivado version that will be used for download xilinx versal'
+        required: true
+        default: '2023.2'
+      x32_defconfigs:
+        description: '32-bit configurations to build'
+        required: true
+        default: 'zynq_zc702_defconfig zynq_zc706_defconfig zynq_zed_defconfig zynq_picozed_defconfig zynq_coraz7_defconfig zynq_adrv9361_defconfig'
+      export_on_server:
+        description: 'Export on server'
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: write
+  actions: read
+
+env: 
+  GCC_BASE_FOLDER: /usr/bin
+  LINARO_FOLDER: /opt/linaro
+  uboot_checkout: u-boot-xlnx
+  ARTIFACTS_NAME: u-boot-artifacts
+  CLOUDSMITH_NAMESPACE: adi
+
+jobs:
+  build-uboot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install GCC 
+        run: |
+          wget https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/arm-linux-gnueabihf/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz
+          sudo mkdir -p ${{env.LINARO_FOLDER}}
+          sudo tar -xf gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz -C /opt/linaro
+          
+          sudo apt update
+          sudo apt install -y gcc-aarch64-linux-gnu
+          
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: analogdevicesinc/u-boot-xlnx
+          ref: master
+          path: ${{env.uboot_checkout}}
+      - name: Create artifacts folder
+        run: |
+          rm -rf ${{env.ARTIFACTS_NAME}}
+          mkdir -p ${{env.ARTIFACTS_NAME}}
+      
+      - name: Run 32 bit configurations
+        working-directory: ${{env.uboot_checkout}}
+        env:
+          GCC_LINARO_FOLDER: ${{env.LINARO_FOLDER}}//gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin
+          ARCH: arm
+          X32_DEFCONFIGS: "${{ inputs.x32_defconfigs }}"
+        run: |
+          export CROSS_COMPILE=${{env.GCC_LINARO_FOLDER}}/arm-linux-gnueabihf-
+          export ARCH=${{env.ARCH}}
+
+          for defcfg in ${{env.X32_DEFCONFIGS}}; do
+             make distclean
+             make $defcfg
+             make -j2
+             echo -e "$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf"
+             cp u-boot "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
+          done
+
+      - name: Install dependencies
+        run: |
+          sudo apt install uuid-dev
+          sudo apt install libgnutls28-dev 
+          sudo apt install device-tree-compiler
+
+      - name: Run 64 bit configurations
+        working-directory: ${{env.uboot_checkout}}
+        env:
+          ARCH: aarch64
+        run: |
+          # build of 64 bit configurations
+          export CROSS_COMPILE=${{env.GCC_BASE_FOLDER}}/aarch64-linux-gnu-
+          export ARCH=${{env.ARCH}}
+          
+          defcfg=adi_zynqmp_adrv9009_zu11eg_adrv2crr_fmc_defconfig
+          make distclean
+          make $defcfg
+          make -j2
+          echo -e "$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf"
+          cp u-boot "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
+
+          defcfg=xilinx_zynqmp_zcu102_revA_defconfig
+          make distclean
+          make $defcfg
+          make -j2
+          echo -e "\n$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf\n"
+          cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
+
+          #build of special cases of kria, jupiter and versal (new flow)
+          git fetch
+          git checkout adi_k26_smk_dts_wrapper
+          
+          export DEVICE_TREE="zynqmp-smk-k26-revA-wrapper"
+          make distclean
+          make xilinx_zynqmp_virt_defconfig
+          make -j2
+          echo -e "\nxilinx_zynqmp_virt_defconfig done. Output file is: u-boot_${DEVICE_TREE}.elf\n"
+          cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${DEVICE_TREE}.elf"
+
+          git checkout jupiter-sdr
+          
+          export DEVICE_TREE="zynqmp-jupiter-sdr"
+          make distclean
+          make xilinx_zynqmp_virt_defconfig
+          make -j2
+          echo -e "\nxilinx_zynqmp_virt_defconfig done. Output file is: u-boot_${DEVICE_TREE}.elf\n"
+          cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${DEVICE_TREE}.elf"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{env.ARTIFACTS_NAME}}
+          path: ${{env.ARTIFACTS_NAME}}/*
+          if-no-files-found: error
+      
+
+  upload_artifacts:
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+    runs-on: ubuntu-latest
+    needs: build-uboot
+    if: ${{ inputs.export_on_server }}
+    steps: 
+      - name: Clean-up artifacts
+        run: |
+          rm -rf ${{env.ARTIFACTS_NAME}}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.ARTIFACTS_NAME}}
+          path: ${{github.workspace}}/${{env.ARTIFACTS_NAME}}
+
+      - name: SwDownlaod upload
+        env:
+          VIVADO_VERSION: ${{inputs.vivado_version}}
+        run: |
+          folder_version=${VIVADO_VERSION//./_r}
+          echo "${{secrets.RSA}}" >secure_file
+          chmod 600 secure_file
+          echo "Files to be uploaded to boot_partition_files/uboot/$folder_version :" 
+          ls ${{env.ARTIFACTS_NAME}}
+          scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -v -i secure_file -r ${{env.ARTIFACTS_NAME}}/* sshacs@analog.ssh.upload.akamai.com:/336936/cse/boot_partition_files/uboot/$folder_version
+
+      - uses: cloudsmith-io/cloudsmith-cli-action@v1.0.5
+        env:
+          CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+        if: ${{ env.CLOUDSMITH_SERVICE_SLUG != '' }}
+        with:
+          oidc-namespace: ${{ env.CLOUDSMITH_NAMESPACE }}
+          oidc-service-slug: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+          oidc-auth-only: 'true'
+
+      - name: Cloudsmith API Key
+        env:
+          CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+        if: ${{ env.CLOUDSMITH_SERVICE_SLUG == '' }}
+        run: echo "CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}" >> "$GITHUB_ENV"
+
+      - name: Cloudsmith upload assets
+        if: ${{ env.CLOUDSMITH_API_KEY != '' }}
+        env: 
+          CLOUDSMITH_REPOSITORY: u-boot
+          VIVADO_VERSION: ${{inputs.vivado_version}}
+        run: |
+          python -m pip install cloudsmith-cli
+          vivado_version=${VIVADO_VERSION//./_r}
+          cd ${{env.ARTIFACTS_NAME}}
+          for f in u-boot_*.elf; do 
+            mv "$f" "${f/u-boot/u-boot_$vivado_version}"
+          done
+          
+          for file in * ; do
+            echo "Upload: $file"
+            cloudsmith push raw --republish -k ${{env.CLOUDSMITH_API_KEY}} adi/${{env.CLOUDSMITH_REPOSITORY}} $file;
+          done

--- a/.github/workflows/build_uboot.yml
+++ b/.github/workflows/build_uboot.yml
@@ -50,7 +50,6 @@ jobs:
           path: ${{env.uboot_checkout}}
       - name: Create artifacts folder
         run: |
-          rm -rf ${{env.ARTIFACTS_NAME}}
           mkdir -p ${{env.ARTIFACTS_NAME}}
       
       - name: Run 32 bit configurations
@@ -66,7 +65,7 @@ jobs:
           for defcfg in ${{env.X32_DEFCONFIGS}}; do
              make distclean
              make $defcfg
-             make -j2
+             make
              echo -e "$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf"
              cp u-boot "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
           done
@@ -96,7 +95,7 @@ jobs:
           defcfg=xilinx_zynqmp_zcu102_revA_defconfig
           make distclean
           make $defcfg
-          make -j2
+          make
           echo -e "\n$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf\n"
           cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
 
@@ -107,7 +106,7 @@ jobs:
           export DEVICE_TREE="zynqmp-smk-k26-revA-wrapper"
           make distclean
           make xilinx_zynqmp_virt_defconfig
-          make -j2
+          make
           echo -e "\nxilinx_zynqmp_virt_defconfig done. Output file is: u-boot_${DEVICE_TREE}.elf\n"
           cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${DEVICE_TREE}.elf"
 
@@ -116,7 +115,7 @@ jobs:
           export DEVICE_TREE="zynqmp-jupiter-sdr"
           make distclean
           make xilinx_zynqmp_virt_defconfig
-          make -j2
+          make
           echo -e "\nxilinx_zynqmp_virt_defconfig done. Output file is: u-boot_${DEVICE_TREE}.elf\n"
           cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${DEVICE_TREE}.elf"
       - name: Upload artifacts

--- a/.github/workflows/build_uboot.yml
+++ b/.github/workflows/build_uboot.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       vivado_version:
-        description: 'Vivado version that will be used for download xilinx versal'
+        description: 'Vivado version'
         required: true
         default: '2023.2'
       x32_defconfigs:
@@ -24,7 +24,7 @@ permissions:
 
 env: 
   GCC_BASE_FOLDER: /usr/bin
-  LINARO_FOLDER: /opt/linaro
+  CUSTOM_GCC_FOLDER: /opt/custom-gcc
   uboot_checkout: u-boot-xlnx
   ARTIFACTS_NAME: u-boot-artifacts
   CLOUDSMITH_NAMESPACE: adi
@@ -35,13 +35,17 @@ jobs:
     steps:
       - name: Install GCC 
         run: |
-          wget https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/arm-linux-gnueabihf/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz
-          sudo mkdir -p ${{env.LINARO_FOLDER}}
-          sudo tar -xf gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz -C /opt/linaro
+          wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz
+          sudo mkdir -p ${{env.CUSTOM_GCC_FOLDER}}
+          sudo tar -xf gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz -C ${{env.CUSTOM_GCC_FOLDER}}
           
           sudo apt update
           sudo apt install -y gcc-aarch64-linux-gnu
-          
+      - name: Install dependencies
+        run: |
+          sudo apt install -y uuid-dev 
+          sudo apt install -y libgnutls28-dev 
+          sudo apt install -y device-tree-compiler
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -55,13 +59,12 @@ jobs:
       - name: Run 32 bit configurations
         working-directory: ${{env.uboot_checkout}}
         env:
-          GCC_LINARO_FOLDER: ${{env.LINARO_FOLDER}}//gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin
+          GCC_CUSTOM_GCC_FOLDER: ${{env.CUSTOM_GCC_FOLDER}}/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf/bin
           ARCH: arm
           X32_DEFCONFIGS: "${{ inputs.x32_defconfigs }}"
         run: |
-          export CROSS_COMPILE=${{env.GCC_LINARO_FOLDER}}/arm-linux-gnueabihf-
+          export CROSS_COMPILE=${{env.GCC_CUSTOM_GCC_FOLDER}}/arm-linux-gnueabihf-
           export ARCH=${{env.ARCH}}
-
           for defcfg in ${{env.X32_DEFCONFIGS}}; do
              make distclean
              make $defcfg
@@ -69,13 +72,6 @@ jobs:
              echo -e "$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf"
              cp u-boot "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
           done
-
-      - name: Install dependencies
-        run: |
-          sudo apt install uuid-dev
-          sudo apt install libgnutls28-dev 
-          sudo apt install device-tree-compiler
-
       - name: Run 64 bit configurations
         working-directory: ${{env.uboot_checkout}}
         env:
@@ -88,10 +84,9 @@ jobs:
           defcfg=adi_zynqmp_adrv9009_zu11eg_adrv2crr_fmc_defconfig
           make distclean
           make $defcfg
-          make -j2
+          make
           echo -e "$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf"
           cp u-boot "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
-
           defcfg=xilinx_zynqmp_zcu102_revA_defconfig
           make distclean
           make $defcfg
@@ -99,10 +94,9 @@ jobs:
           echo -e "\n$defcfg done. Output file is: u-boot_${defcfg//_defconfig/}.elf\n"
           cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${defcfg//_defconfig/}.elf"
 
-          #build of special cases of kria, jupiter and versal (new flow)
+          # k26 dts build
           git fetch
           git checkout adi_k26_smk_dts_wrapper
-          
           export DEVICE_TREE="zynqmp-smk-k26-revA-wrapper"
           make distclean
           make xilinx_zynqmp_virt_defconfig
@@ -110,8 +104,8 @@ jobs:
           echo -e "\nxilinx_zynqmp_virt_defconfig done. Output file is: u-boot_${DEVICE_TREE}.elf\n"
           cp u-boot.elf "../${{env.ARTIFACTS_NAME}}/u-boot_${DEVICE_TREE}.elf"
 
+          # jupiter sdr build
           git checkout jupiter-sdr
-          
           export DEVICE_TREE="zynqmp-jupiter-sdr"
           make distclean
           make xilinx_zynqmp_virt_defconfig
@@ -124,8 +118,7 @@ jobs:
           name: ${{env.ARTIFACTS_NAME}}
           path: ${{env.ARTIFACTS_NAME}}/*
           if-no-files-found: error
-      
-
+    
   upload_artifacts:
     permissions:
       id-token: write
@@ -138,7 +131,6 @@ jobs:
       - name: Clean-up artifacts
         run: |
           rm -rf ${{env.ARTIFACTS_NAME}}
-
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -155,7 +147,6 @@ jobs:
           echo "Files to be uploaded to boot_partition_files/uboot/$folder_version :" 
           ls ${{env.ARTIFACTS_NAME}}
           scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -v -i secure_file -r ${{env.ARTIFACTS_NAME}}/* sshacs@analog.ssh.upload.akamai.com:/336936/cse/boot_partition_files/uboot/$folder_version
-
       - uses: cloudsmith-io/cloudsmith-cli-action@v1.0.5
         env:
           CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}


### PR DESCRIPTION
This workflow builds U-Boot for various Xilinx platforms, allowing for both 32-bit and 64-bit configurations. It includes steps for installing dependencies, creating artifacts, and uploading them to Cloudsmith.
The upload is on SwDownload and also in the cloudsmith using the slug API token. 
As a default GCC we need to use an old version because they drop the armv5
`arm-linux-gnueabihf-gcc: error: unrecognized -march target: armv5`
I used a version from linaro.org that have the desire version

A new cloudsmith repo was created for this workflow 